### PR TITLE
Adding the missing parameters for creating the next available Subnet in a Address block

### DIFF
--- a/ipamsvc/address_block/address_block_create_next_available_subnet_parameters.go
+++ b/ipamsvc/address_block/address_block_create_next_available_subnet_parameters.go
@@ -7,6 +7,7 @@ package address_block
 
 import (
 	"context"
+	"github.com/go-openapi/swag"
 	"net/http"
 	"time"
 
@@ -59,11 +60,38 @@ func NewAddressBlockCreateNextAvailableSubnetParamsWithHTTPClient(client *http.C
 */
 type AddressBlockCreateNextAvailableSubnetParams struct {
 
-	/* ID.
+	/* Cidr.
+	   The cidr value of subnets to be created.
+	   Format: int32
+	*/
+	Cidr *int32
 
+	/* Comment.
+	   Comment of next available subnets.
+	*/
+	Comment *string
+
+	/* Count.
+	   Number of subnets to generate. Default 1 if not set.
+	   Format: int32
+	*/
+	Count *int32
+
+	/* DhcpHost.
+	   Reference of OnPrem Host associated with the next available subnets to be created.
+	*/
+	DhcpHost *string
+
+	/* ID.
 	   An application specific resource identity of a resource
 	*/
 	ID string
+
+	/* Name.
+	   Name of next available subnets.
+	*/
+	Name *string
+
 
 	timeout    time.Duration
 	Context    context.Context
@@ -118,6 +146,50 @@ func (o *AddressBlockCreateNextAvailableSubnetParams) SetHTTPClient(client *http
 	o.HTTPClient = client
 }
 
+// WithCidr adds the cidr to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) WithCidr(cidr *int32) *AddressBlockCreateNextAvailableSubnetParams {
+	o.SetCidr(cidr)
+	return o
+}
+
+// SetCidr adds the cidr to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) SetCidr(cidr *int32) {
+	o.Cidr = cidr
+}
+
+// WithComment adds the comment to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) WithComment(comment *string) *AddressBlockCreateNextAvailableSubnetParams {
+	o.SetComment(comment)
+	return o
+}
+
+// SetComment adds the comment to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) SetComment(comment *string) {
+	o.Comment = comment
+}
+
+// WithCount adds the count to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) WithCount(count *int32) *AddressBlockCreateNextAvailableSubnetParams {
+	o.SetCount(count)
+	return o
+}
+
+// SetCount adds the count to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) SetCount(count *int32) {
+	o.Count = count
+}
+
+// WithDhcpHost adds the dhcpHost to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) WithDhcpHost(dhcpHost *string) *AddressBlockCreateNextAvailableSubnetParams {
+	o.SetDhcpHost(dhcpHost)
+	return o
+}
+
+// SetDhcpHost adds the dhcpHost to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) SetDhcpHost(dhcpHost *string) {
+	o.DhcpHost = dhcpHost
+}
+
 // WithID adds the id to the address block create next available subnet params
 func (o *AddressBlockCreateNextAvailableSubnetParams) WithID(id string) *AddressBlockCreateNextAvailableSubnetParams {
 	o.SetID(id)
@@ -129,6 +201,17 @@ func (o *AddressBlockCreateNextAvailableSubnetParams) SetID(id string) {
 	o.ID = id
 }
 
+// WithName adds the name to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) WithName(name *string) *AddressBlockCreateNextAvailableSubnetParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the address block create next available subnet params
+func (o *AddressBlockCreateNextAvailableSubnetParams) SetName(name *string) {
+	o.Name = name
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *AddressBlockCreateNextAvailableSubnetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -137,11 +220,96 @@ func (o *AddressBlockCreateNextAvailableSubnetParams) WriteToRequest(r runtime.C
 	}
 	var res []error
 
+	if o.Cidr != nil {
+
+		// query param cidr
+		var qrCidr int32
+
+		if o.Cidr != nil {
+			qrCidr = *o.Cidr
+		}
+		qCidr := swag.FormatInt32(qrCidr)
+		if qCidr != "" {
+
+			if err := r.SetQueryParam("cidr", qCidr); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Comment != nil {
+
+		// query param comment
+		var qrComment string
+
+		if o.Comment != nil {
+			qrComment = *o.Comment
+		}
+		qComment := qrComment
+		if qComment != "" {
+
+			if err := r.SetQueryParam("comment", qComment); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Count != nil {
+
+		// query param count
+		var qrCount int32
+
+		if o.Count != nil {
+			qrCount = *o.Count
+		}
+		qCount := swag.FormatInt32(qrCount)
+		if qCount != "" {
+
+			if err := r.SetQueryParam("count", qCount); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.DhcpHost != nil {
+
+		// query param dhcp_host
+		var qrDhcpHost string
+
+		if o.DhcpHost != nil {
+			qrDhcpHost = *o.DhcpHost
+		}
+		qDhcpHost := qrDhcpHost
+		if qDhcpHost != "" {
+
+			if err := r.SetQueryParam("dhcp_host", qDhcpHost); err != nil {
+				return err
+			}
+		}
+	}
+
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
 	}
 
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
+				return err
+			}
+		}
+	}
+	
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}


### PR DESCRIPTION
To support the creation of the Next Available Subnet in an Address Block. The added Params are sent in QueryParams and are used in the creation.